### PR TITLE
switch to ubuntu:zesty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM phusion/baseimage:0.9.22
+#FROM phusion/baseimage:0.9.22
+FROM ubuntu:zesty-20171114
 
 LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -6,23 +6,26 @@ set -e -o pipefail
 # https://github.com/phusion/baseimage-docker/issues/58
 DEBIAN_FRONTEND=noninteractive
 
-# Minimal ubnutu images need the following:
+# Add some basics
 apt-get update
-apt-get install -y -qq lsb-release
+apt-get install -y -qq --no-install-recommends \
+	lsb-release ca-certificates wget rsync curl \
+	python-crcmod less nano vim git locales make \
+	liblz4-tool pigz bzip2 lbzip2
 
-# phusion/baseimage is based on xenial, but in case something changes,
-# auto-detect here:
+# Auto-detect platform
 DEBIAN_PLATFORM="$(lsb_release -c -s)"
 echo "Debian platform: $DEBIAN_PLATFORM"
 
+# Add source for gcloud sdk
 echo "deb http://packages.cloud.google.com/apt cloud-sdk-$DEBIAN_PLATFORM main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
+# Install gcloud and aws
 apt-get install -y -qq --no-install-recommends \
-	ca-certificates wget rsync curl \
-	python-crcmod less nano vim git locales make \
-	google-cloud-sdk awscli \
-	liblz4-tool pigz bzip2 lbzip2
+	google-cloud-sdk awscli
+
+# Upgrade and clean
 apt-get upgrade -y
 apt-get clean
 

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -2,24 +2,27 @@
 
 set -e -o pipefail
 
+# Silence some warnings about Readline. Checkout more over her$
+# https://github.com/phusion/baseimage-docker/issues/58
+DEBIAN_FRONTEND=noninteractive
+
+# Minimal ubnutu images need the following:
+apt-get update
+apt-get install -y -qq lsb-release
+
 # phusion/baseimage is based on xenial, but in case something changes,
 # auto-detect here:
 DEBIAN_PLATFORM="$(lsb_release -c -s)"
 echo "Debian platform: $DEBIAN_PLATFORM"
 
-# Silence some warnings about Readline. Checkout more over her$
-# https://github.com/phusion/baseimage-docker/issues/58
-DEBIAN_FRONTEND=noninteractive
-
 echo "deb http://packages.cloud.google.com/apt cloud-sdk-$DEBIAN_PLATFORM main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
-apt-get update
 apt-get install -y -qq --no-install-recommends \
 	ca-certificates wget rsync curl \
 	python-crcmod less nano vim git locales make \
 	google-cloud-sdk awscli \
-	liblz4-tool pigz bzip2
+	liblz4-tool pigz bzip2 lbzip2
 apt-get upgrade -y
 apt-get clean
 

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -11,6 +11,7 @@ apt-get update
 apt-get install -y -qq --no-install-recommends \
 	lsb-release ca-certificates wget rsync curl \
 	python-crcmod less nano vim git locales make \
+	dirmngr \
 	liblz4-tool pigz bzip2 lbzip2
 
 # Auto-detect platform

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -22,6 +22,7 @@ echo "deb http://packages.cloud.google.com/apt cloud-sdk-$DEBIAN_PLATFORM main" 
 curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 
 # Install gcloud and aws
+apt-get update
 apt-get install -y -qq --no-install-recommends \
 	google-cloud-sdk awscli
 


### PR DESCRIPTION
Update from xenial-based phusion/baseimage to ubuntu:zesty. Reduces image compressed size by about 20% and eliminates a bunch of addressable CVE issues from docker security scans (including CVE-2017-9445 which just recently classified as "High" severity).