### PR TITLE
update baseimage to meltdown-patched artful

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #FROM phusion/baseimage:0.9.22
-FROM ubuntu:zesty-20171114
+FROM ubuntu:artful-20180112
 
 LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
+[![Docker Repository on Quay](https://quay.io/repository/broadinstitute/viral-baseimage/status "Docker Repository on Quay")](https://quay.io/repository/broadinstitute/viral-baseimage)
+
 # viral-baseimage
 
-This contains the code to build the Docker image for 
-`docker.io/broadinstitute/viral-baseimage`. This image is
-based on phusion/baseimage (minimal Ubuntu Docker image)
-and contains a number of generally useful utilities
-for Viral Genomics work on the cloud:
+This contains the code to build the Docker image for
+`quay.io/broadinstitute/viral-baseimage`. This image is based on ubuntu
+and contains a number of generally useful utilities for Viral Genomics
+work on the cloud:
 
  - google-cloud-sdk, awscli, dx-toolkit: for interacting with
 Google Cloud, Amazon Web Services, and DNAnexus


### PR DESCRIPTION
Update baseimage from xenial-20171114 to artful-20180112. Should address Meltdown (Variant 3). Spectre (Variants 1 & 2) patches are still being worked on upstream. [More info](https://wiki.ubuntu.com/SecurityTeam/KnowledgeBase/SpectreAndMeltdown).