### PR TITLE
update to artful 20180123

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-#FROM phusion/baseimage:0.9.22
-FROM ubuntu:artful-20180112
+FROM ubuntu:artful-20180123
 
 LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
 


### PR DESCRIPTION
This now includes [spectre patches](https://wiki.ubuntu.com/SecurityTeam/KnowledgeBase/SpectreAndMeltdown) (previous 20180112 was meltdown-only)