### PR TITLE
upgrade baseimage to Ubuntu 22.04 LTS jammy (+ related updates)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-FROM ubuntu:focal-20211006
+FROM ubuntu:jammy-20230126
 
-LABEL maintainer "Chris Tomkins-Tinch <tomkinsc@broadinstitute.org>"
+LABEL maintainer "viral-ngs team <viral-ngs@broadinstitute.org>"
 
 COPY install-*.sh /opt/docker/
 
-# System packages, Google Cloud SDK, and locale
+# System packages, Google Cloud CLI, and locale
 # ca-certificates and wget needed for gosu
 # bzip2, liblz4-toolk, and pigz are useful for packaging and archival
-# google-cloud-sdk needed when using this in GCE
+# google-cloud-cli needed when using this in GCE
 RUN /opt/docker/install-apt_packages.sh
 
 # Set default locale to en_US.UTF-8
-ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8"
+ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8" TZ="UTC"
 
 # install miniwdl
-RUN pip3 install --system miniwdl==1.4.1
+RUN pip3 install miniwdl==1.8.0
 ENV MINIWDL__SCHEDULER__CONTAINER_BACKEND=udocker
 
 # install udocker

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 viral-baseimage is distribtued under the following BSD-style license:
 
-Copyright © 2018 Broad Institute, Inc.  All rights reserved.
+Copyright © 2023 Broad Institute, Inc.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without 
 modification, are permitted provided that the following conditions are 

--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 # viral-baseimage
 
 This contains the code to build the Docker image for
-`quay.io/broadinstitute/viral-baseimage`. This image is based on ubuntu
+`quay.io/broadinstitute/viral-baseimage`. This image is based on Ubuntu
 and contains a number of generally useful utilities for Viral Genomics
 work on the cloud:
 
- - google-cloud-sdk, awscli, dx-toolkit: for interacting with
+ - google-cloud-cli, awscli, dx-toolkit: for interacting with
 Google Cloud, Amazon Web Services, and DNAnexus
  - a few compression utilities
  - Miniconda
- - udocker
+ - [udocker](https://github.com/indigo-dc/udocker)

--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -9,27 +9,28 @@ echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 
 # Add some basics
 apt-get update
+apt-get install -y -qq --no-install-recommends apt-transport-https && apt-get update
 apt-get install -y -qq --no-install-recommends \
-	lsb-release ca-certificates wget rsync curl python-is-python3 python3-pip \
+	lsb-release ca-certificates gnupg wget rsync curl python-is-python3 python3-pip \
 	python3-crcmod less nano vim git locales make \
-	dirmngr parallel gnupg file \
-	liblz4-tool pigz bzip2 lbzip2 zip unzip zstd \
-	ttf-dejavu
+	dirmngr parallel file \
+	liblz4-tool pigz bzip2 lbzip2 zip unzip zstd xz-utils \
+	fonts-dejavu
 
 ## Auto-detect platform
 #DEBIAN_PLATFORM="$(lsb_release -c -s)"
 #echo "Debian platform: $DEBIAN_PLATFORM"
-DEBIAN_PLATFORM=bionic
-echo "faking bionic release for google cloud sdk"
+#DEBIAN_PLATFORM=bionic
+#echo "faking bionic release for google cloud sdk"
 
 # Add source for gcloud sdk
-echo "deb http://packages.cloud.google.com/apt cloud-sdk-$DEBIAN_PLATFORM main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
 
 # Install gcloud and aws
 apt-get update
 apt-get install -y -qq --no-install-recommends \
-	google-cloud-sdk awscli
+	google-cloud-cli awscli
 
 # Upgrade and clean
 apt-get upgrade -y

--- a/install-dnanexus-cli.sh
+++ b/install-dnanexus-cli.sh
@@ -2,11 +2,11 @@
 
 set -e -o pipefail -u
 
-DX_TOOLKIT_VERSION=0.291.1
-DX_UPLOAD_AGENT_VERSION=1.5.31
+DX_TOOLKIT_VERSION=0.325.1
+DX_UPLOAD_AGENT_VERSION=1.5.33
 
 # get the dx-toolkit
-curl -s https://dnanexus-sdk.s3.amazonaws.com/dx-toolkit-v${DX_TOOLKIT_VERSION}-ubuntu-14.04-amd64.tar.gz | tar -xzp
+curl -s https://dnanexus-sdk.s3.amazonaws.com/dx-toolkit-v${DX_TOOLKIT_VERSION}-ubuntu-16.04-amd64.tar.gz | tar -xzp
 
 #get the ua
 curl -s https://dnanexus-sdk.s3.amazonaws.com/dnanexus-upload-agent-${DX_UPLOAD_AGENT_VERSION}-linux.tar.gz | tar -xzp

--- a/install-dnanexus-cli.sh
+++ b/install-dnanexus-cli.sh
@@ -8,7 +8,7 @@ DX_UPLOAD_AGENT_VERSION=1.5.33
 # get the dx-toolkit
 curl -s https://dnanexus-sdk.s3.amazonaws.com/dx-toolkit-v${DX_TOOLKIT_VERSION}-ubuntu-16.04-amd64.tar.gz | tar -xzp
 
-#get the ua
+#get the dnanexus upload agent (ua agent)
 curl -s https://dnanexus-sdk.s3.amazonaws.com/dnanexus-upload-agent-${DX_UPLOAD_AGENT_VERSION}-linux.tar.gz | tar -xzp
 mv dnanexus-upload-agent-${DX_UPLOAD_AGENT_VERSION}-linux/ua dx-toolkit/bin
 rmdir dnanexus-upload-agent-${DX_UPLOAD_AGENT_VERSION}-linux

--- a/install-miniconda.sh
+++ b/install-miniconda.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e -o pipefail
 
-MINICONDA_VERSION="4.7.12.1"
-MINICONDA_URL="https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
+MINICONDA_VERSION="py310_23.1.0-1"
+MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 
 # download and run miniconda installer script
 curl -sSL $MINICONDA_URL > "/tmp/Miniconda3-${MINICONDA_VERSION}-x86_64.sh"

--- a/install-udocker.sh
+++ b/install-udocker.sh
@@ -2,11 +2,11 @@
 set -e -o pipefail
 
 UDOCKER_PATH=/usr/local/udocker
-UDOCKER_VERSION=1.3.1
+UDOCKER_VERSION=1.3.7
 
-curl -L https://github.com/indigo-dc/udocker/releases/download/v$UDOCKER_VERSION/udocker-$UDOCKER_VERSION.tar.gz \
+curl -L https://github.com/indigo-dc/udocker/releases/download/$UDOCKER_VERSION/udocker-$UDOCKER_VERSION.tar.gz \
  | tar -xzv
-mv udocker /usr/local
+mv udocker-$UDOCKER_VERSION/udocker /usr/local
 
 echo '#!/bin/bash' > /usr/local/bin/udocker
 echo '/usr/local/udocker/udocker --allow-root "$@"' >> /usr/local/bin/udocker


### PR DESCRIPTION
* update baseimage to Ubuntu 22.04 LTS (jammy)
* rename gcp packag `google-cloud-cli` (new name for `google-cloud-sdk`)
* install `xz-utils` for lzma/xz compressed files
* explicitly set `TZ` environment variable to `UTC` (which is the assumption already) in order to reduce the number of C system calls asking for the timezone (see [here](https://blog.packagecloud.io/set-environment-variable-save-thousands-of-system-calls/))
* bump `miniwdl` 1.4.1 -> 1.8.0
* bump `dx-toolkit` 0.291.1 -> 0.325.1
* bump dx upload agent 1.5.31 -> 1.5.33
* change miniconda source from `continuum.io` to `anaconda.com`
* bump `miniconda` version 4.7.12.1 -> py310_23.1.0-1
* bump `udocker` 1.3.1 -> 1.3.7
* rename `ttf-dejavu` -> `fonts-dejavu` to reflect package name change upstream