### PR TITLE
add qsv to docker image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build the Docker image
       run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,9 @@ RUN /opt/docker/install-udocker.sh
 # install DNAnexus SDK and UA
 RUN /opt/docker/install-dnanexus-cli.sh
 
+# install qsv (binary for manipulation and query of tabular data files like tsv)
+RUN /opt/docker/install-qsv.sh
+
 # install miniconda3 with our default channels and no other packages
 ENV MINICONDA_PATH="/opt/miniconda"
 RUN /opt/docker/install-miniconda.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy-20230126
+FROM ubuntu:jammy-20240227
 
 LABEL maintainer "viral-ngs team <viral-ngs@broadinstitute.org>"
 

--- a/install-miniconda.sh
+++ b/install-miniconda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-MINICONDA_VERSION="py310_23.1.0-1"
+MINICONDA_VERSION="py310_24.1.2-0"
 MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 
 # download and run miniconda installer script

--- a/install-qsv.sh
+++ b/install-qsv.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+# This installs qsv:
+#   "a command line program for querying, indexing, slicing, analyzing, filtering, enriching,
+#    transforming, sorting, validating & joining CSV files"
+#
+# Additional information available here:
+#   https://github.com/jqnatividad/qsv
+#
+# Additional information on available releases (including the latest versions) available here:
+#   https://github.com/jqnatividad/qsv/releases
+
+QSV_BINARY=qsvlite # "qsv" is the binary with all features enabled; "qsvlite" has extra features disabled and is much smaller in size
+QSV_VERSION=0.123.0
+
+case "$(uname -m)" in
+  x86_64)
+    CPU_ARCH="x86_64"
+    ;;
+  arm64 | aarch64)
+    CPU_ARCH="aarch64" #"aarch64" for Apple Silicon and other ARM-based CPUs
+    ;;
+  *)
+    CPU_ARCH="unknown"
+    echo "Unknown CPU architecture returned by uname -m: '${CPU_ARCH}'" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -s)" in
+  Linux)
+    OS_BUILD_TYPE="unknown-linux-gnu" # "unknown-linux-musl" for Linux platforms where libc compatability is an issue, otherwise "unknown-linux-gnu"
+    ;;
+  Darwin)
+    OS_BUILD_TYPE="apple-darwin"
+    ;;
+  *)
+    OS_BUILD_TYPE="unknown"
+    echo "Unknown OS type returned by uname -s: '${OS_BUILD_TYPE}'" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v curl &> /dev/null; then
+    echo "curl is required but it does not appear to be installed" >&2
+    exit 1
+fi
+
+PACKAGE_ZIP=qsv-${QSV_VERSION}-${CPU_ARCH}-${OS_BUILD_TYPE}.zip
+
+echo "Downloading binary for ${OS_BUILD_TYPE} built for ${CPU_ARCH}: ${PACKAGE_ZIP}"
+curl --silent --location --output $PACKAGE_ZIP https://github.com/jqnatividad/qsv/releases/download/${QSV_VERSION}/${PACKAGE_ZIP}
+
+# unzip only the qsv binary to its final location (the zip archive also contains alternate builds)
+unzip -o -d /usr/local/bin $PACKAGE_ZIP ${QSV_BINARY}
+rm $PACKAGE_ZIP
+
+chmod 755 /usr/local/bin/${QSV_BINARY}
+
+# if copying in an alternate build of qsv, symlink it to "qsv"
+if [[ "$QSV_BINARY" != "qsv" ]]; then
+    if [ ! -f /usr/local/bin/qsv ]; then
+        ln -s /usr/local/bin/${QSV_BINARY} /usr/local/bin/qsv
+    fi
+fi
+
+hash -r
+
+if ! command -v qsv &> /dev/null; then
+    echo "The qsv installation seems to have failed" >&2
+    exit 1
+else
+    echo "qsv installation successful."
+fi
+


### PR DESCRIPTION
This adds [`qsv`](https://github.com/jqnatividad/qsv) to the Docker image, a tool for manipulating and querying tabular text files (tsv, csv).
The `qsv` binary is installed from a tagged release available on GitHub since `qsv` is not yet available via an apt repo.
The zip archive distributed for qsv contains several builds, each with varying features enabled. To reduce the image space required for qsv, the install script included in this PR currently adds only the `qsvlite` binary (also available as symlink named `qsv`), which is much smaller in size than the fully-featured `qsv`. 