### PR TITLE
update miniwdl and udocker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN /opt/docker/install-apt_packages.sh
 ENV LANG="en_US.UTF-8" LANGUAGE="en_US:en" LC_ALL="en_US.UTF-8" TZ="UTC"
 
 # install miniwdl
-RUN pip3 install miniwdl==1.8.0
+RUN pip3 install miniwdl==1.11.1
 ENV MINIWDL__SCHEDULER__CONTAINER_BACKEND=udocker
 
 # install udocker

--- a/install-udocker.sh
+++ b/install-udocker.sh
@@ -2,15 +2,12 @@
 set -e -o pipefail
 
 UDOCKER_PATH=/usr/local/udocker
-UDOCKER_VERSION=1.3.7
+UDOCKER_VERSION=1.3.16
 
 curl -L https://github.com/indigo-dc/udocker/releases/download/$UDOCKER_VERSION/udocker-$UDOCKER_VERSION.tar.gz \
  | tar -xzv
 mv udocker-$UDOCKER_VERSION/udocker /usr/local
-
-echo '#!/bin/bash' > /usr/local/bin/udocker
-echo '/usr/local/udocker/udocker --allow-root "$@"' >> /usr/local/bin/udocker
-chmod +x /usr/local/bin/udocker
+ln -s /usr/local/udocker/udocker /usr/local/bin/
 
 #cd $UDOCKER_PATH
 #udocker install


### PR DESCRIPTION
Update miniwdl and udocker versions -- also remove the custom udocker script that injects an `--allow-root` as miniwdl now appends that anyway for udocker backends.