### PR TITLE
install bsdmainutils

### DIFF
--- a/install-apt_packages.sh
+++ b/install-apt_packages.sh
@@ -11,7 +11,7 @@ echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 apt-get update
 apt-get install -y -qq --no-install-recommends apt-transport-https && apt-get update
 apt-get install -y -qq --no-install-recommends \
-	lsb-release ca-certificates gnupg wget rsync curl python-is-python3 python3-pip \
+	lsb-release ca-certificates gnupg wget rsync curl python-is-python3 python3-pip bsdmainutils \
 	python3-crcmod less nano vim git locales make bc \
 	dirmngr parallel file \
 	liblz4-tool pigz bzip2 lbzip2 zip unzip zstd xz-utils \


### PR DESCRIPTION
include the [bsdmainutils](https://launchpad.net/ubuntu/trusty/+package/bsdmainutils) apt package in the image (~450kB)

bsdmainutils "provides `banner` (as printerbanner), `calendar`, `col`, `colcrt`, `colrm`, `column`, `from` (as bsd-from), `hexdump` (or hd), `look`, `lorder`, `ncal` (or `cal`), `ul`, and `write` (as bsd-write)."

This is primarily being added for the `column` command for padding columns to be aligned (for human-readable output in logs and elsewhere).