### PR TITLE
bump miniconda version 24.1.2 -> 24.11.1

### DIFF
--- a/install-miniconda.sh
+++ b/install-miniconda.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e -o pipefail
 
-MINICONDA_VERSION="py310_24.1.2-0"
+MINICONDA_VERSION="py310_24.11.1-0"
 MINICONDA_URL="https://repo.anaconda.com/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-x86_64.sh"
 
 # download and run miniconda installer script


### PR DESCRIPTION
bump miniconda version 24.1.2 -> 24.11.1, while retaining python 3.10 for the base environment (for now)
The image will be transitioned to a micromamba-based image following the merge of #29 